### PR TITLE
receipt paper Printer support

### DIFF
--- a/app/src/main/kotlin/io/github/toolicious/labler/model/Label.kt
+++ b/app/src/main/kotlin/io/github/toolicious/labler/model/Label.kt
@@ -28,6 +28,7 @@ data class LabelSpec(
             12 to 40,
             14 to 30, 14 to 40,
             15 to 30, 15 to 40,
+            53 to 105, 80 to 105,
         )
     }
 }

--- a/app/src/main/kotlin/io/github/toolicious/labler/ui/home/HomeScreen.kt
+++ b/app/src/main/kotlin/io/github/toolicious/labler/ui/home/HomeScreen.kt
@@ -486,7 +486,7 @@ internal fun LabelDialog(
         },
         confirmButton = {
             val submit = {
-                val width = widthText.toIntOrNull()?.coerceIn(10, 15) ?: 12
+                val width = widthText.toIntOrNull()?.coerceIn(10, 80) ?: 12
                 val length = lengthText.toIntOrNull()?.coerceIn(10, 500) ?: 40
                 val media = if (dieCut) MediaType.DIE_CUT else MediaType.CONTINUOUS
                 onConfirm(name, LabelSpec(width, length, media))


### PR DESCRIPTION
Hi there,

I have a GooJPRT PT-210 Receipt paper roll Printer and this App is really nice to also Print labels on it.
Since this works great to print, I think this app would support a lot of different thermal printers, not only the L15 Label printer. The only thing which is a little confusing to other thermal print app is, that the Label is Horizontal and not Vertical.

It is just, that the print Height does not allow to print in the full Height (Width of the endless Roll).
Normal printdimensions of these devices are 53 and 80mm. Therefore I propose the change to allow Heights up to 80mm and added Presets for 53 and 80mm. (Previously the Height is capped at 15mm).

Otherwise good work with this app. Nice UI, reliable connection and nice Print.

<img width="4032" height="3024" alt="13345b24-f0e9-42e6-9e30-fa1aa3d8670b" src="https://github.com/user-attachments/assets/2ea094a9-ad3a-42ab-a482-8b0c9028e832" />

Sincerely Eric